### PR TITLE
AI real data fix

### DIFF
--- a/CRaidUI.lua
+++ b/CRaidUI.lua
@@ -5,6 +5,9 @@ local NUM_TEST_RAID_MEMBERS = 10
 -- Require CDebuff.lua
 local CDebuff = require("CDebuff")
 
+-- Global test mode switch
+local TEST_MODE = false
+
 -- Function to generate dummy data for testing
 function GenerateDummyData()
     local dummyData = {}
@@ -25,6 +28,24 @@ function GenerateDummyData()
     return dummyData
 end
 
+-- Function to fetch real data from the game
+function FetchRealData()
+    local realData = {}
+    for i = 1, NUM_TEST_RAID_MEMBERS do
+        local unit = "raid" .. i
+        if UnitExists(unit) then
+            table.insert(realData, {
+                name = UnitName(unit),
+                health = UnitHealth(unit),
+                mana = UnitMana(unit),
+                class = UnitClass(unit),
+                debuffs = GetUnitDebuffs(unit)
+            })
+        end
+    end
+    return realData
+end
+
 -- Function to get class color
 function GetClassColor(class)
     local classColors = {
@@ -41,13 +62,13 @@ function GetClassColor(class)
     return classColors[class] or {r = 1.0, g = 1.0, b = 1.0}
 end
 
--- Function to handle dummy data and update the raid frames
-function UpdateRaidFrames(dummyData)
+-- Function to handle data and update the raid frames
+function UpdateRaidFrames(data)
     for i = 1, NUM_TEST_RAID_MEMBERS do
         local raidFrame = _G["RaidFrame" .. i]
         if raidFrame then
-            if i <= #dummyData then
-                local player = dummyData[i]
+            if i <= #data then
+                local player = data[i]
                 raidFrame:Show()
                 raidFrame.name:SetText(player.name)
                 raidFrame.health:SetValue(player.health)
@@ -79,6 +100,11 @@ function UpdateRaidFrames(dummyData)
     end
 end
 
--- Initialize the raid frames with dummy data for testing
-local dummyData = GenerateDummyData()
-UpdateRaidFrames(dummyData)
+-- Initialize the raid frames with data
+local data
+if TEST_MODE then
+    data = GenerateDummyData()
+else
+    data = FetchRealData()
+end
+UpdateRaidFrames(data)

--- a/CRaidUI.xml
+++ b/CRaidUI.xml
@@ -5,6 +5,8 @@
                 self:RegisterEvent("RAID_ROSTER_UPDATE");
                 self:RegisterEvent("UNIT_HEALTH");
                 self:RegisterEvent("UNIT_MANA");
+                data = FetchRealData();
+                UpdateRaidFrames(data);
             </OnLoad>
             <OnEvent>
                 if (event == "RAID_ROSTER_UPDATE" or (event == "UNIT_HEALTH" and arg1:find("raid")) or (event == "UNIT_MANA" and arg1:find("raid"))) then

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ AI implemented raid frame for 2.4.3
 ## Project intent
 
 * Our primary goal is to create a robust framework for testing the interface layout.
-* We will use dummy data when possible or necessary to ensure the interface is thoroughly tested.
+* We will use real data from the game to ensure the interface is thoroughly tested.
 * This approach will help us identify and resolve any issues early in the development process, ensuring a smooth and efficient user experience.


### PR DESCRIPTION
Fixes #1

Re-enable real data mode for raid frames.

* Add a global test mode switch in `CRaidUI.lua` to toggle between dummy data and real data.
* Implement `FetchRealData` function in `CRaidUI.lua` to fetch real data from the game.
* Update `UpdateRaidFrames` function in `CRaidUI.lua` to handle both dummy data and real data.
* Modify `CRaidUI.xml` to initialize raid frames with real data on load and update on relevant events.
* Update `README.md` to reflect the use of real data for testing the interface layout.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AiAnswer3213/CyborgRaidFrame/issues/1?shareId=2ee48ac9-56d8-4281-a403-b1ee9cbc07a3).